### PR TITLE
update module path in go.mod

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gfleury/go-bitbucket-v1"
+	"github.com/clyphub/go-bitbucket-v1"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gfleury/go-bitbucket-v1
+module github.com/clyphub/go-bitbucket-v1
 
 go 1.14
 


### PR DESCRIPTION
We have forked this repository to use it as Bitbucket version 1 REST API in the brit tool.
Updating go.mod file to update module path.