### PR TITLE
CLYPD-44264: added missing support to set requestbody parameter while creating branch

### DIFF
--- a/default_api.go
+++ b/default_api.go
@@ -665,10 +665,9 @@ func (a *DefaultApiService) CreatePullRequest(projectKey, repositorySlug string,
 Creates a branch using the information provided in the {@link RestCreateBranchRequest request}  &lt;p&gt;  The authenticated user must have &lt;strong&gt;REPO_WRITE&lt;/strong&gt; permission for the context repository to call  this resource.
 
 @return */
-func (a *DefaultApiService) CreateBranch(projectKey, repositorySlug string) (*APIResponse, error) {
+func (a *DefaultApiService) CreateBranch(projectKey, repositorySlug string, localVarPostBody interface{}) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
 	)

--- a/default_api.go
+++ b/default_api.go
@@ -663,9 +663,12 @@ func (a *DefaultApiService) CreatePullRequest(projectKey, repositorySlug string,
 
 /* DefaultApiService
 Creates a branch using the information provided in the {@link RestCreateBranchRequest request}  &lt;p&gt;  The authenticated user must have &lt;strong&gt;REPO_WRITE&lt;/strong&gt; permission for the context repository to call  this resource.
-
+REQUEST QUERY PARAMETERS
+parameter			|			value			|	description
+filterText			|			strin			|	the text to match on
+orderBy				|			string			|	ordering of refs either ALPHABETICAL (by name) or MODIFICATION (last updated)
 @return */
-func (a *DefaultApiService) CreateBranch(projectKey, repositorySlug string, PostBody interface{}) (*APIResponse, error) {
+func (a *DefaultApiService) CreateBranch(projectKey, repositorySlug string, postBody map[string]interface{}) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Post")
 		localVarFileName   string
@@ -698,7 +701,7 @@ func (a *DefaultApiService) CreateBranch(projectKey, repositorySlug string, Post
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, PostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, postBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/default_api.go
+++ b/default_api.go
@@ -665,7 +665,7 @@ func (a *DefaultApiService) CreatePullRequest(projectKey, repositorySlug string,
 Creates a branch using the information provided in the {@link RestCreateBranchRequest request}  &lt;p&gt;  The authenticated user must have &lt;strong&gt;REPO_WRITE&lt;/strong&gt; permission for the context repository to call  this resource.
 
 @return */
-func (a *DefaultApiService) CreateBranch(projectKey, repositorySlug string, localVarPostBody interface{}) (*APIResponse, error) {
+func (a *DefaultApiService) CreateBranch(projectKey, repositorySlug string, PostBody interface{}) (*APIResponse, error) {
 	var (
 		localVarHTTPMethod = strings.ToUpper("Post")
 		localVarFileName   string
@@ -698,7 +698,7 @@ func (a *DefaultApiService) CreateBranch(projectKey, repositorySlug string, loca
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(a.client.ctx, localVarPath, localVarHTTPMethod, PostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/default_api_test.go
+++ b/default_api_test.go
@@ -623,7 +623,7 @@ func TestDefaultApiService_CreateBranch(t *testing.T) {
 	type args struct {
 		projectKey     string
 		repositorySlug string
-		PostBody   interface{}
+		postBody       map[string]interface{}
 	}
 	tests := []struct {
 		name                     string
@@ -642,7 +642,7 @@ func TestDefaultApiService_CreateBranch(t *testing.T) {
 			a := &DefaultApiService{
 				client: tt.fields.client,
 			}
-			got, err := a.CreateBranch(tt.args.projectKey, tt.args.repositorySlug, tt.args.PostBody)
+			got, err := a.CreateBranch(tt.args.projectKey, tt.args.repositorySlug, tt.args.postBody)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DefaultApiService.CreateBranch() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/default_api_test.go
+++ b/default_api_test.go
@@ -623,7 +623,7 @@ func TestDefaultApiService_CreateBranch(t *testing.T) {
 	type args struct {
 		projectKey     string
 		repositorySlug string
-		localVarPostBody   interface{}
+		PostBody   interface{}
 	}
 	tests := []struct {
 		name                     string
@@ -642,7 +642,7 @@ func TestDefaultApiService_CreateBranch(t *testing.T) {
 			a := &DefaultApiService{
 				client: tt.fields.client,
 			}
-			got, err := a.CreateBranch(tt.args.projectKey, tt.args.repositorySlug, tt.args.localVarPostBody)
+			got, err := a.CreateBranch(tt.args.projectKey, tt.args.repositorySlug, tt.args.PostBody)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DefaultApiService.CreateBranch() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/default_api_test.go
+++ b/default_api_test.go
@@ -623,6 +623,7 @@ func TestDefaultApiService_CreateBranch(t *testing.T) {
 	type args struct {
 		projectKey     string
 		repositorySlug string
+		localVarPostBody   interface{}
 	}
 	tests := []struct {
 		name                     string
@@ -641,7 +642,7 @@ func TestDefaultApiService_CreateBranch(t *testing.T) {
 			a := &DefaultApiService{
 				client: tt.fields.client,
 			}
-			got, err := a.CreateBranch(tt.args.projectKey, tt.args.repositorySlug)
+			got, err := a.CreateBranch(tt.args.projectKey, tt.args.repositorySlug, tt.args.localVarPostBody)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DefaultApiService.CreateBranch() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
**Link to JIRA ticket:** https://jira.xandr-services.com/browse/CLYPD-44264

Library code mostly auto-gen code by swagger for the client, so it doesn't have support to set request body params in create branch API client method.

Hence added missing support to pass request body parameter while creating a branch

**Required For:** https://github.com/clyphub/gillnet/pull/13417